### PR TITLE
remove modelSchema from json

### DIFF
--- a/packages/overreact/src/schema/schema-node.js
+++ b/packages/overreact/src/schema/schema-node.js
@@ -34,7 +34,7 @@ export class SchemaNode {
     return ({
       name: this.name,
       modelName: this.modelName,
-      modelSchema: this.modelSchema,
+      // modelSchema: this.modelSchema, Can contain non-serializable properties
       childNodes: this.childNodes.length > 0 ? this.childNodes.map(c => c.toJson()) : undefined,
       extensions: Object.keys(this.extensions).length > 0
         ? Object.keys(this.extensions).map(k => this.extensions[k].toJson()) : undefined,


### PR DESCRIPTION
Removing modelSchema from `toJson()` as it may contain non-serializable properties